### PR TITLE
Demonstrate simple selectors backed by inline fragments

### DIFF
--- a/src/__generated__/selectorsGetCompletedTodoCount.graphql.js
+++ b/src/__generated__/selectorsGetCompletedTodoCount.graphql.js
@@ -1,0 +1,18 @@
+/**
+ * @generated SignedSource<<57bfc7cbba386e55e4d0a69ab36e105a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+var node = {
+  "kind": "InlineDataFragment",
+  "name": "selectorsGetCompletedTodoCount"
+};
+
+node.hash = "2f2d811e88b2a7d9626819c5a5c2d656";
+
+module.exports = node;

--- a/src/__generated__/selectorsGetTodoCount.graphql.js
+++ b/src/__generated__/selectorsGetTodoCount.graphql.js
@@ -1,0 +1,18 @@
+/**
+ * @generated SignedSource<<7449b0742c9c13d1fded0d040921e713>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+var node = {
+  "kind": "InlineDataFragment",
+  "name": "selectorsGetTodoCount"
+};
+
+node.hash = "f20706bed1c59a5cc12724b7a70fbd50";
+
+module.exports = node;

--- a/src/__generated__/selectorsGetVisibilityFilter.graphql.js
+++ b/src/__generated__/selectorsGetVisibilityFilter.graphql.js
@@ -1,0 +1,18 @@
+/**
+ * @generated SignedSource<<46a59c86b087e65dba9e42616725bef2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+var node = {
+  "kind": "InlineDataFragment",
+  "name": "selectorsGetVisibilityFilter"
+};
+
+node.hash = "436021856542e188fbf768b6f9a080ae";
+
+module.exports = node;

--- a/src/__generated__/selectorsGetVisibleTodos.graphql.js
+++ b/src/__generated__/selectorsGetVisibleTodos.graphql.js
@@ -1,0 +1,18 @@
+/**
+ * @generated SignedSource<<712d8b450d73c6a4c4190f9909cc25aa>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+var node = {
+  "kind": "InlineDataFragment",
+  "name": "selectorsGetVisibleTodos"
+};
+
+node.hash = "42b466d965b0357007f9e7f6a39cc606";
+
+module.exports = node;

--- a/src/__generated__/storeStateQuery.graphql.js
+++ b/src/__generated__/storeStateQuery.graphql.js
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ba212761ec0219c4a8e61a2221f18041>>
+ * @generated SignedSource<<2334c5d5f4f54b83664c82e32c5d9d85>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,59 +9,130 @@
 'use strict';
 
 var node = (function(){
-var v0 = [
-  {
-    "kind": "ClientExtension",
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Todo",
-        "kind": "LinkedField",
-        "name": "all_todos",
-        "plural": true,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "text",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "completed",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "visibility_filter",
-        "storageKey": null
-      }
-    ]
-  }
-];
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "visibility_filter",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "completed",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
-    "metadata": null,
+    "metadata": {
+      "hasClientEdges": true
+    },
     "name": "storeStateQuery",
-    "selections": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "InlineDataFragmentSpread",
+        "name": "selectorsGetVisibilityFilter",
+        "selections": [
+          {
+            "kind": "ClientExtension",
+            "selections": [
+              (v0/*: any*/)
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "InlineDataFragmentSpread",
+        "name": "selectorsGetVisibleTodos",
+        "selections": [
+          {
+            "kind": "ClientEdgeToClientObject",
+            "concreteType": "Todo",
+            "backingField": {
+              "alias": null,
+              "args": null,
+              "fragment": {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "RootVisibleTodosResolver"
+              },
+              "kind": "RelayResolver",
+              "name": "visible_todos",
+              "resolverModule": require('./../relay/resolvers/RootVisibleTodosResolver.js'),
+              "path": "visible_todos"
+            },
+            "linkedField": {
+              "alias": null,
+              "args": null,
+              "concreteType": "Todo",
+              "kind": "LinkedField",
+              "name": "visible_todos",
+              "plural": true,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "text",
+                  "storageKey": null
+                },
+                (v2/*: any*/)
+              ],
+              "storageKey": null
+            }
+          }
+        ]
+      },
+      {
+        "kind": "InlineDataFragmentSpread",
+        "name": "selectorsGetCompletedTodoCount",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "fragment": {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "RootCompletedTodosCountResolver"
+            },
+            "kind": "RelayResolver",
+            "name": "completed_todos_count",
+            "resolverModule": require('./../relay/resolvers/RootCompletedTodosCountResolver.js'),
+            "path": "completed_todos_count"
+          }
+        ]
+      },
+      {
+        "kind": "InlineDataFragmentSpread",
+        "name": "selectorsGetTodoCount",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "fragment": {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "RootTodosCountResolver"
+            },
+            "kind": "RelayResolver",
+            "name": "todos_count",
+            "resolverModule": require('./../relay/resolvers/RootTodosCountResolver.js'),
+            "path": "todos_count"
+          }
+        ]
+      }
+    ],
     "type": "Root",
     "abstractKey": null
   },
@@ -70,7 +141,34 @@ return {
     "argumentDefinitions": [],
     "kind": "Operation",
     "name": "storeStateQuery",
-    "selections": (v0/*: any*/)
+    "selections": [
+      {
+        "kind": "ClientExtension",
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Todo",
+            "kind": "LinkedField",
+            "name": "all_todos",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ]
+      }
+    ]
   },
   "params": {
     "cacheID": "45b902dadb3555c469df635a325839ca",
@@ -83,6 +181,6 @@ return {
 };
 })();
 
-node.hash = "b4dcba6cf943125b5ab07d0ee4437bf0";
+node.hash = "df1e64577d74a936e4f38a7cda437222";
 
 module.exports = node;

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import { render } from "react-dom";
 import store from "./store";
 import { Provider } from "react-redux";
 import App from "./components/App";
+import LegacyApp from "./legacyComponents/App";
 import "todomvc-app-css/index.css";
 import { RelayEnvironmentProvider } from "react-relay/hooks";
 import RelayEnvironment from "./relay/RelayEnvironment";
 
-render(
-  <RelayEnvironmentProvider environment={RelayEnvironment}>
-    <React.Suspense fallback={"Loading..."}>
-      <Provider store={store}>
-        <App />
-      </Provider>
-    </React.Suspense>
-  </RelayEnvironmentProvider>,
-  document.getElementById("root")
-);
+function Root() {
+  const [legacy, setLegacy] = useState(false);
+  return (
+    <RelayEnvironmentProvider environment={RelayEnvironment}>
+      <React.Suspense fallback={"Loading..."}>
+        <Provider store={store}>
+          {legacy ? <LegacyApp /> : <App />}
+          <div style={{ paddingTop: 100 }}>
+            <label>
+              Legacy:{" "}
+              <input
+                type="checkbox"
+                onChange={(e) => setLegacy(e.target.checked)}
+              />
+            </label>
+          </div>
+        </Provider>
+      </React.Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+
+render(<Root />, document.getElementById("root"));

--- a/src/legacyComponents/App.js
+++ b/src/legacyComponents/App.js
@@ -1,0 +1,12 @@
+import React from "react";
+import Header from "./Header";
+import MainSection from "./MainSection";
+
+const App = () => (
+  <div>
+    <Header />
+    <MainSection />
+  </div>
+);
+
+export default App;

--- a/src/legacyComponents/FilterLink.js
+++ b/src/legacyComponents/FilterLink.js
@@ -1,0 +1,30 @@
+import React from "react";
+import classnames from "classnames";
+import { connect } from "react-redux";
+import { setVisibilityFilter } from "../actions";
+import { getVisibilityFilter } from "../selectors";
+
+const Link = ({ active, children, setFilter }) => {
+  return (
+    // eslint-disable jsx-a11y/anchor-is-valid
+    <a
+      className={classnames({ selected: active })}
+      style={{ cursor: "pointer" }}
+      onClick={() => setFilter()}
+    >
+      {children}
+    </a>
+  );
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  active: ownProps.filter === getVisibilityFilter(state),
+});
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  setFilter: () => {
+    dispatch(setVisibilityFilter(ownProps.filter));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Link);

--- a/src/legacyComponents/Footer.js
+++ b/src/legacyComponents/Footer.js
@@ -1,0 +1,39 @@
+import React from "react";
+import FilterLink from "./FilterLink";
+import {
+  SHOW_ALL,
+  SHOW_COMPLETED,
+  SHOW_ACTIVE,
+} from "../constants/TodoFilters";
+
+const FILTER_TITLES = {
+  [SHOW_ALL]: "All",
+  [SHOW_ACTIVE]: "Active",
+  [SHOW_COMPLETED]: "Completed",
+};
+
+const Footer = (props) => {
+  const { activeCount, completedCount, onClearCompleted } = props;
+  const itemWord = activeCount === 1 ? "item" : "items";
+  return (
+    <footer className="footer">
+      <span className="todo-count">
+        <strong>{activeCount || "No"}</strong> {itemWord} left
+      </span>
+      <ul className="filters">
+        {Object.keys(FILTER_TITLES).map((filter) => (
+          <li key={filter}>
+            <FilterLink filter={filter}>{FILTER_TITLES[filter]}</FilterLink>
+          </li>
+        ))}
+      </ul>
+      {!!completedCount && (
+        <button className="clear-completed" onClick={onClearCompleted}>
+          Clear completed
+        </button>
+      )}
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/legacyComponents/Header.js
+++ b/src/legacyComponents/Header.js
@@ -1,0 +1,23 @@
+import React from "react";
+import TodoTextInput from "./TodoTextInput";
+import { connect } from "react-redux";
+import { addTodo } from "../actions";
+
+const Header = ({ addTodo }) => {
+  return (
+    <header className="header">
+      <h1>todos (legacy)</h1>
+      <TodoTextInput
+        newTodo
+        onSave={(text) => {
+          if (text.length !== 0) {
+            addTodo(text);
+          }
+        }}
+        placeholder="What needs to be done?"
+      />
+    </header>
+  );
+};
+
+export default connect(null, { addTodo })(Header);

--- a/src/legacyComponents/MainSection.js
+++ b/src/legacyComponents/MainSection.js
@@ -1,0 +1,44 @@
+import React from "react";
+import Footer from "./Footer";
+import VisibleTodoList from "./VisibleTodoList";
+import { connect } from "react-redux";
+import * as TodoActions from "../actions";
+import { bindActionCreators } from "redux";
+import { getCompletedTodoCount, getTodosCount } from "../selectors";
+
+const MainSection = ({ todosCount, completedCount, actions }) => {
+  return (
+    <section className="main">
+      {!!todosCount && (
+        <span>
+          <input
+            className="toggle-all"
+            type="checkbox"
+            checked={completedCount === todosCount}
+            readOnly
+          />
+          <label onClick={actions.completeAllTodos} />
+        </span>
+      )}
+      <VisibleTodoList />
+      {!!todosCount && (
+        <Footer
+          completedCount={completedCount}
+          activeCount={todosCount - completedCount}
+          onClearCompleted={actions.clearCompleted}
+        />
+      )}
+    </section>
+  );
+};
+
+const mapStateToProps = (state) => ({
+  todosCount: getTodosCount(state),
+  completedCount: getCompletedTodoCount(state),
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  actions: bindActionCreators(TodoActions, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MainSection);

--- a/src/legacyComponents/TodoItem.js
+++ b/src/legacyComponents/TodoItem.js
@@ -1,0 +1,58 @@
+import React, { useCallback, useState } from "react";
+import classnames from "classnames";
+import TodoTextInput from "./TodoTextInput";
+
+export default function TodoItem({ editTodo, deleteTodo, todo, completeTodo }) {
+  const [editing, setEditing] = useState(false);
+
+  const handleDoubleClick = () => {
+    setEditing(true);
+  };
+
+  const handleSave = useCallback(
+    (id, text) => {
+      if (text.length === 0) {
+        deleteTodo(id);
+      } else {
+        editTodo(id, text);
+      }
+      setEditing(false);
+    },
+    [editTodo, deleteTodo]
+  );
+
+  let element;
+  if (editing) {
+    element = (
+      <TodoTextInput
+        text={todo.text}
+        editing={editing}
+        onSave={(text) => handleSave(todo.id, text)}
+      />
+    );
+  } else {
+    element = (
+      <div className="view">
+        <input
+          className="toggle"
+          type="checkbox"
+          checked={todo.completed}
+          onChange={() => completeTodo(todo.id)}
+        />
+        <label onDoubleClick={handleDoubleClick}>{todo.text}</label>
+        <button className="destroy" onClick={() => deleteTodo(todo.id)} />
+      </div>
+    );
+  }
+
+  return (
+    <li
+      className={classnames({
+        completed: todo.completed,
+        editing,
+      })}
+    >
+      {element}
+    </li>
+  );
+}

--- a/src/legacyComponents/TodoTextInput.js
+++ b/src/legacyComponents/TodoTextInput.js
@@ -1,0 +1,48 @@
+import React from "react";
+import classnames from "classnames";
+
+export default function TodoTextInput({
+  text: initialText,
+  onSave,
+  newTodo,
+  placeholder,
+  editing,
+}) {
+  const [text, setText] = React.useState(initialText || "");
+
+  const handleSubmit = (e) => {
+    const text = e.target.value.trim();
+    if (e.which === 13) {
+      onSave(text);
+      if (newTodo) {
+        setText("");
+      }
+    }
+  };
+
+  const handleChange = (e) => {
+    setText(e.target.value);
+  };
+
+  const handleBlur = (e) => {
+    if (!newTodo) {
+      onSave(e.target.value);
+    }
+  };
+
+  return (
+    <input
+      className={classnames({
+        edit: editing,
+        "new-todo": newTodo,
+      })}
+      type="text"
+      placeholder={placeholder}
+      autoFocus={true}
+      value={text}
+      onBlur={handleBlur}
+      onChange={handleChange}
+      onKeyDown={handleSubmit}
+    />
+  );
+}

--- a/src/legacyComponents/VisibleTodoList.js
+++ b/src/legacyComponents/VisibleTodoList.js
@@ -1,0 +1,26 @@
+import React from "react";
+import TodoItem from "./TodoItem";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import * as TodoActions from "../actions";
+import { getVisibleTodos } from "../selectors";
+
+const TodoList = ({ filteredTodos, actions }) => {
+  return (
+    <ul className="todo-list">
+      {filteredTodos.map((todo) => (
+        <TodoItem key={todo.id} todo={todo} {...actions} />
+      ))}
+    </ul>
+  );
+};
+
+const mapStateToProps = (state) => ({
+  filteredTodos: getVisibleTodos(state),
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  actions: bindActionCreators(TodoActions, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TodoList);

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,67 @@
+import graphql from "babel-plugin-relay/macro";
+import { readInlineData } from "relay-runtime";
+
+/**
+ * For compatibility with legacy parts of the app which still read state via selectors,
+ * we can provide an implementation of each public selector which is defined
+ * using a GraphQL fragment.
+ *
+ * In this world, Relay store is the source of truth for all concrete data
+ * (server or client), and Resolvers are the source of truth for all _derived_
+ * data. This holds for new code (reading via Relay) and legacy code (reading
+ * via selectors).
+ *
+ * **TODO**: This approach will not work in use cases where data in the query can suspend.
+ * Something more robust will be needed to handle that case.
+ */
+export const getVisibilityFilter = (state) => {
+  const data = readInlineData(
+    graphql`
+      fragment selectorsGetVisibilityFilter on Root @inline {
+        visibility_filter
+      }
+    `,
+    state
+  );
+  return data.visibility_filter;
+};
+
+export const getVisibleTodos = (state) => {
+  const data = readInlineData(
+    graphql`
+      fragment selectorsGetVisibleTodos on Root @inline {
+        visible_todos {
+          id
+          text
+          completed
+        }
+      }
+    `,
+    state
+  );
+  return data.visible_todos;
+};
+
+export const getCompletedTodoCount = (state) => {
+  const data = readInlineData(
+    graphql`
+      fragment selectorsGetCompletedTodoCount on Root @inline {
+        completed_todos_count
+      }
+    `,
+    state
+  );
+  return data.completed_todos_count;
+};
+
+export const getTodosCount = (state) => {
+  const data = readInlineData(
+    graphql`
+      fragment selectorsGetTodoCount on Root @inline {
+        todos_count
+      }
+    `,
+    state
+  );
+  return data.todos_count;
+};

--- a/src/store.js
+++ b/src/store.js
@@ -15,12 +15,10 @@ import { createOperationDescriptor } from "relay-runtime";
 
 const STATE_QUERY = graphql`
   query storeStateQuery {
-    all_todos {
-      id
-      text
-      completed
-    }
-    visibility_filter
+    ...selectorsGetVisibilityFilter
+    ...selectorsGetVisibleTodos
+    ...selectorsGetCompletedTodoCount
+    ...selectorsGetTodoCount
   }
 `;
 
@@ -30,7 +28,7 @@ class CompatibilityStore {
   constructor() {
     this._callbacks = [];
 
-    // Relay does not yet have an API for innitializing the default
+    // Relay does not yet have an API for initializing the default
     // value in client schema extensions, so we'll set the default values
     // using actions:
     this.dispatch({ type: SET_VISIBILITY_FILTER, filter: SHOW_ALL });
@@ -98,26 +96,8 @@ class CompatibilityStore {
   // Maps a Relay query to the legacy Redux state object
   // shape.
   _stateFromQuery(data) {
-    return {
-      todos: data.all_todos.map((todo) => ({
-        text: todo.text,
-        id: todo.id,
-        completed: todo.completed,
-      })),
-      visibilityFilter: data.visibility_filter,
-    };
+    return data;
   }
-}
-
-function relayIdToReduxId(id) {
-  // This is to work around the fact that Relay resolvers to client types
-  // namespace their IDs. Here we un-prefix them. We need to find a fix for
-  // this is Relay itself.
-  const regex = /^client:Todo:(.*)$/;
-  if (!regex.test(id)) {
-    throw new Error("Expected special client id syntax.");
-  }
-  return id.replace(regex, "$1");
 }
 
 function setVisibilityFilter(filter) {


### PR DESCRIPTION
This PR demonstrates building a compatibility layer where all legacy selectors are re-implemented using fragments as their source of truth, rather than deriving the entire Flux state atom in the compatibility store. This approach would be useful in a few cases:

1. You have a number of legacy components which have not yet been migrated to Relay, and still expect to be able to read state via selectors
2. You have large portions of your app which, realistically, will not get migrated to the new infrastructure, but you want them to be able to read from the same source of truth as the migrated portions of the app.

The PR introduces a "legacy" mode which uses all the original Redux components to render the exact same UI as the the original app. This is intended to demonstrate that you could have a portion of your app still reading via selectors and they would observe the same source of truth.

There are two main advantage of this approach over the current approach modeled in the repo (where a single state atom, having the same shape as the  is derived in the compatibility store):

1. Selectors are implemented as reading Relay Resolver fiends directly. This ensures there is only one source of truth for the logic that derives the derived state (the Relay Resolver)
2. As you migrate more of your app and delete unused selectors, Relay will automatically remove any data dependencies which are not needed by the legacy part of the app.

## Limitations

This approach is not complete. When you want to load actual state from the server, use Client Edges, or Live Resolvers that can suspend, there will be edge cases where the selectors will not be in a loaded state, and thus cannot be read. I plan to explore that in future work that builds upon this PR.

## Next Steps

I would like this end state to be modeled in the actual Repo at some point. Once I have a satisfactory solution to the limitations outlined above, I will work on a way to incorporate this back in.